### PR TITLE
chore: remove references to versions and use <VERSION> instead

### DIFF
--- a/docs/drash/v2.x/1_getting_started/1_introduction.md
+++ b/docs/drash/v2.x/1_getting_started/1_introduction.md
@@ -20,7 +20,9 @@ Learn more about Drash [here](about-drash).
   ```typescript
   // app.ts
 
-  import * as Drash from "https://deno.land/x/drash@v2.0.0/mod.ts";
+  // Replace `<VERSION>` with the Drash version you want to use.
+  // All versions can be found at https://github.com/drashland/drash/releases.
+  import * as Drash from "https://deno.land/x/drash@<VERSION>/mod.ts";
 
   // Create your resource
 

--- a/docs/drash/v2.x/1_getting_started/4_migration_guide_to_v2.md
+++ b/docs/drash/v2.x/1_getting_started/4_migration_guide_to_v2.md
@@ -186,7 +186,12 @@ The below example application contains the following:
 * A server with a service that executes on all requests
 
 ```typescript
-import * as Drash from "http://deno.land/x/drash@v2.0.0/mod.ts";
+// app.ts
+
+
+// Replace `<VERSION>` with the Drash version you want to use.
+// All versions can be found at https://github.com/drashland/drash/releases.
+import * as Drash from "http://deno.land/x/drash@<VERSION>/mod.ts";
 
 ////////////////////////////////////////////////////////////////////////////////
 // FILE MARKER - SERVICES //////////////////////////////////////////////////////

--- a/docs/drash/v2.x/2_tutorials/1_introduction/1_add_drash_as_a_dependency.md
+++ b/docs/drash/v2.x/2_tutorials/1_introduction/1_add_drash_as_a_dependency.md
@@ -12,10 +12,12 @@ Before you get started with any tutorial, make sure you create a `deps.ts` file 
 ```typescript
 // deps.ts
 
-export * as Drash from "https://deno.land/x/drash@v2.0.0/mod.ts"
+export * as Drash from "https://deno.land/x/drash@<VERSION>/mod.ts"
 ```
 
-This file is **_required_** for all tutorials. Tutorials will reference this `deps.ts` file in code blocks like so:
+Replace `<VERSION>` with the Drash version you want to use. All versions can be found [here](https://github.com/drashland/drash/releases).
+
+The `deps.ts` file is **_required_** for all tutorials. Tutorials will reference the `deps.ts` file in code blocks like so:
 
 ```typescript
 // some_file.ts

--- a/docs/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/2_csrf.md
+++ b/docs/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/2_csrf.md
@@ -25,8 +25,10 @@ To use this service, edit your `deps.ts` file to include the service.
 ...
 ...
 ...
-import { CSRFService } from "https://deno.land/drash@v2.0.0/services.ts";
+export { CSRFService } from "https://deno.land/drash@<VERSION>/services.ts";
 ```
+
+Replace `<VERSION>` with the Drash version you want to use. All versions can be found [here](https://github.com/drashland/drash/releases).
 
 ## Folder Structure End State
 

--- a/docs/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/3_paladin.md
+++ b/docs/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/3_paladin.md
@@ -34,8 +34,10 @@ To use this service, edit your `deps.ts` file to include the service.
 ...
 ...
 ...
-import { PaladinService } from "https://deno.land/drash@v2.0.0/services.ts";
+export { PaladinService } from "https://deno.land/drash@<VERSION>/services.ts";
 ```
+
+Replace `<VERSION>` with the Drash version you want to use. All versions can be found [here](https://github.com/drashland/drash/releases).
 
 ## Folder Structure End State
 

--- a/docs_in_progress/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/1_cors.md
+++ b/docs_in_progress/drash/v2.x/2_tutorials/6_services/5_drash_approved_services/1_cors.md
@@ -24,8 +24,10 @@ To use this service, edit your `deps.ts` file to include the service.
 ...
 ...
 ...
-import { CORSService } from "https://deno.land/drash@v2.0.0/services.ts";
+import { CORSService } from "https://deno.land/drash@<VERSION>/services.ts";
 ```
+
+Replace `<VERSION>` with the Drash version you want to use. All versions can be found [here](https://github.com/drashland/drash/releases).
 
 ## Folder Structure End State
 


### PR DESCRIPTION
Closes #19 

## What has been done

- Changed all references of an actual version in Drash to be `<VERSION>` and provided and link to Drash's releases page