### PR TITLE
docs(drash/v2.x): Document status and header params on response methods

### DIFF
--- a/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
+++ b/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
@@ -21,19 +21,28 @@ on a response and send that body to clients.
 Below are the built-in body methods on the `response` object and examples of how
 to use each one in a resource.
 
-All of the below methods, you are able to pass in a custom response status, and any extra response headers, though these are optional. The status defaults to `200` and the `headers` defaults to an empty array. For example, we'll use `json()` for this demonstration:
+All of the below methods, you are able to pass in a custom response status, and
+any extra response headers, though these are optional. The status defaults to
+`200` and the `headers` defaults to an empty array. For example, we'll use
+`json()` for this demonstration:
 
 ```ts
-response.json({
-  success: false,
-  message: 'Authentication failed',
-}, 403, {
-  'X-REQUEST-FAILED': 'true',
-  'X-TRY-AGAIN': '6s',
-})
+response.json(
+  {
+    success: false,
+    message: "Authentication failed",
+  },
+  403,
+  {
+    "X-REQUEST-FAILED": "true",
+    "X-TRY-AGAIN": "6s",
+  },
+);
 ```
 
-Upon calling the above, when the response is sent, the status will now be 403, and on top of the content-type header these methods set, two extra headers will be present.
+Upon calling the above, when the response is sent, the status will now be 403,
+and on top of the content-type header these methods set, two extra headers will
+be present.
 
 ### download()
 
@@ -103,7 +112,8 @@ Upon calling the above, when the response is sent, the status will now be 403, a
 
 ### text()
 
-- Use this method to send raw text to clients. This can be used as a basic "Hello world" example.
+- Use this method to send raw text to clients. This can be used as a basic
+  "Hello world" example.
 - Example Usage
 
   ```typescript

--- a/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
+++ b/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
@@ -21,10 +21,10 @@ on a response and send that body to clients.
 Below are the built-in body methods on the `response` object and examples of how
 to use each one in a resource.
 
-You are able to pass in a custom response status, and
-any extra response headers for all of the methods below (bar `download()`), though these are optional. The status defaults to
-`200` and the `headers` defaults to an empty array. For example, we'll use
-`json()` for this demonstration:
+You are able to pass in a custom response status, and any extra response headers
+for all of the methods below (bar `download()`), though these are optional. The
+status defaults to `200` and the `headers` defaults to an empty array. For
+example, we'll use `json()` for this demonstration:
 
 ```ts
 response.json(
@@ -118,7 +118,6 @@ be present.
 
   ```typescript
   public GET(request: Drash.Request, response: Drash.Response): void {
-    const xml = Deno.readFileSync("./path/to/file.xml");
     return response.text("Hello world");
   }
   ```

--- a/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
+++ b/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
@@ -21,8 +21,8 @@ on a response and send that body to clients.
 Below are the built-in body methods on the `response` object and examples of how
 to use each one in a resource.
 
-All of the below methods, you are able to pass in a custom response status, and
-any extra response headers, though these are optional. The status defaults to
+You are able to pass in a custom response status, and
+any extra response headers for all of the methods below (bar `download()`), though these are optional. The status defaults to
 `200` and the `headers` defaults to an empty array. For example, we'll use
 `json()` for this demonstration:
 

--- a/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
+++ b/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
@@ -12,6 +12,7 @@ on a response and send that body to clients.
   - [html()](#html)
   - [json()](#json)
   - [xml()](#xml)
+  - [text()](#text)
 - [How Body Methods Work](#how-body-methods-work)
 - [Custom Response Bodies](#custom-response-bodies)
 
@@ -19,6 +20,20 @@ on a response and send that body to clients.
 
 Below are the built-in body methods on the `response` object and examples of how
 to use each one in a resource.
+
+All of the below methods, you are able to pass in a custom response status, and any extra response headers, though these are optional. The status defaults to `200` and the `headers` defaults to an empty array. For example, we'll use `json()` for this demonstration:
+
+```ts
+response.json({
+  success: false,
+  message: 'Authentication failed',
+}, 403, {
+  'X-REQUEST-FAILED': 'true',
+  'X-TRY-AGAIN': '6s',
+})
+```
+
+Upon calling the above, when the response is sent, the status will now be 403, and on top of the content-type header these methods set, two extra headers will be present.
 
 ### download()
 
@@ -83,6 +98,18 @@ to use each one in a resource.
     const xml = Deno.readFileSync("./path/to/file.xml");
     return response.xml(xml);
     // or return response.xml("<body>Hello, world!</body>");
+  }
+  ```
+
+### text()
+
+- Use this method to send raw text to clients. This can be used as a basic "Hello world" example.
+- Example Usage
+
+  ```typescript
+  public GET(request: Drash.Request, response: Drash.Response): void {
+    const xml = Deno.readFileSync("./path/to/file.xml");
+    return response.text("Hello world");
   }
   ```
 


### PR DESCRIPTION
for https://github.com/drashland/drash/pull/598

Also includes documentation the `text` method as that was missing
