### PR TITLE
fix Line's getting-started compile instruction

### DIFF
--- a/docs/line/v1.x/1_getting_started/1_introduction.md
+++ b/docs/line/v1.x/1_getting_started/1_introduction.md
@@ -53,7 +53,7 @@ Learn more about Line [here](/line/v1.x/getting-started/about-line).
    signature. In this case, we are using `my-cli`, so that will be the name.
 
    ```shell
-   $ deno install --name my-cli cli.ts
+   $ deno install --name my-cli my_cli.ts
    ```
 
    This should install a `my-cli` executable that you can execute through your


### PR DESCRIPTION

## Summary

* The getting started instructions for Line say to compile `cli.ts` but the previous step said to to name it `my_cli.ts`.
* Change `cli.ts` to `my_cli.ts`

