### PR TITLE
add deps.ts reference to single-command intro

### DIFF
--- a/docs/line/v1.x/2_tutorials/2_creating_a_cli/1_single_command_clis/2_part_1_entry_points.md
+++ b/docs/line/v1.x/2_tutorials/2_creating_a_cli/1_single_command_clis/2_part_1_entry_points.md
@@ -15,6 +15,8 @@ In this tutorial part, you will create your entry point file (`cli.ts`) and your
 At the end of this tutorial part, you will have a CLI that will be able to show
 a help menu and version.
 
+Before continuing, create a `deps.ts` file by following the [add Line as a Dependency](/line/v1.x/tutorials/introduction/add-line-as-a-dependency#add-line-as-a-dependency) instructions.
+
 ## Folder Structure End State
 
 ```text

--- a/docs/line/v1.x/2_tutorials/2_creating_a_cli/1_single_command_clis/2_part_1_entry_points.md
+++ b/docs/line/v1.x/2_tutorials/2_creating_a_cli/1_single_command_clis/2_part_1_entry_points.md
@@ -15,7 +15,9 @@ In this tutorial part, you will create your entry point file (`cli.ts`) and your
 At the end of this tutorial part, you will have a CLI that will be able to show
 a help menu and version.
 
-Before continuing, create a `deps.ts` file by following the [add Line as a Dependency](/line/v1.x/tutorials/introduction/add-line-as-a-dependency#add-line-as-a-dependency) instructions.
+Before continuing, create a `deps.ts` file by following the
+[add Line as a Dependency](/line/v1.x/tutorials/introduction/add-line-as-a-dependency#add-line-as-a-dependency)
+instructions.
 
 ## Folder Structure End State
 


### PR DESCRIPTION
related to #96

## Summary

* links to the deps.ts creation docs from the single-command intro

## Other Notes

I missed this when following the single-command intro and was confused about where deps.ts was supposed to come from.  Maybe this could help others too.