### PR TITLE
The Connection header may contain other values

### DIFF
--- a/docs/drash/v2.x/2_tutorials/4_requests/8_handling_websocket_connections.md
+++ b/docs/drash/v2.x/2_tutorials/4_requests/8_handling_websocket_connections.md
@@ -63,7 +63,7 @@ class HomeResource extends Drash.Resource {
     if (
       request.headers.has("connection") &&
       request.headers.has("upgrade") &&
-      request.headers.get("connection")!.toLowerCase() == "upgrade" &&
+      request.headers.get("connection")!.toLowerCase().includes("upgrade") &&
       request.headers.get("upgrade")!.toLowerCase() == "websocket"
     ) {
       try {


### PR DESCRIPTION
The Connection header may contain other values (e.g. keep-alive on Firefox)

## Summary

Update of the websocket documentation

## Other Notes

The code provided in the documentation did not work on Firefox because the Connection header contained a different value:
Connection : keep-alive, Upgrade