### PR TITLE
fix(drash/v2.x): Fixed typo in example when using response.send

### DIFF
--- a/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
+++ b/docs/drash/v2.x/2_tutorials/5_responses/1_setting_the_body.md
@@ -170,6 +170,6 @@ header, then use the `.send()` method.
   ```typescript
   public GET(request: Drash.Request, response: Drash.Response): void {
     const typescript = Deno.readFileSync("/path/to/my/typescript/file.ts");
-    return response.send<string>("application/typescript", body);
+    return response.send<string>("application/typescript", typescript);
   }
   ```


### PR DESCRIPTION
Closes #107 

## Summary

Renamed `body` to `typescript`


