### PR TITLE
Fix: Missing comma added and typo in import

### DIFF
--- a/docs/drash/v2.x/2_tutorials/6_services/2_adding_server_level_services.md
+++ b/docs/drash/v2.x/2_tutorials/6_services/2_adding_server_level_services.md
@@ -18,7 +18,7 @@ const server = new Drash.Server({
   resources: [ ... ],
   // All services must be instantiated using the `new` keyword in this array
   services: [
-    new ServerService(),
+    new SomeService(),
     new SomeOtherService(),
   ],
 });

--- a/docs/drash/v2.x/2_tutorials/6_services/2_adding_server_level_services.md
+++ b/docs/drash/v2.x/2_tutorials/6_services/2_adding_server_level_services.md
@@ -18,7 +18,7 @@ const server = new Drash.Server({
   resources: [ ... ],
   // All services must be instantiated using the `new` keyword in this array
   services: [
-    new ServerService()
+    new ServerService(),
     new SomeOtherService(),
   ],
 });


### PR DESCRIPTION
Closes #110 
## Summary

Added comma in examples
