### PR TITLE
feat: tabbed code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,115 @@ environment on a different port._
 
 3. Go to `http://localhost:3000`
 
+## Writing Documentation
+
+All documentation is written using Markdown and stored in the `/docs` directory.
+The `/docs` directory is read by `/pages/[...path_params].jsx` which utilizes
+`react-markdown` to render the Markdown files.
+
+In addition to Markdown syntax, this repository can also do the following with
+Markdown (with the help of `react-markdown` and Prism.js):
+
+- Syntax highlighting
+- Diff highlighting in specific languages
+- Tabbed example code blocks
+
+When writing documentation, you can use the additional features as outlined
+below.
+
+### Syntax Highlighting
+
+To add syntax highlighting to a fenced code block, add the language you want to
+highlight by starting a fenced code block with the following:
+
+<pre>
+```{language-goes-here}
+</pre>
+
+The above will cause `react-markdown` to add a `language-{language-goes-here}`
+class name to the code block and call Prism.js to highlight the code.
+
+As an example, using `typescript` to start a fenced code block ...
+
+<pre>
+```typescript
+import * as something from "./something.ts";
+```
+</pre>
+
+... renders as ...
+
+![Syntax Highlight](https://user-images.githubusercontent.com/12766301/163730086-586d950c-3e64-4707-b263-57ff3b4238a2.png)
+
+### Diff + Syntax Highlighting
+
+To add diff and syntax highlighting to a fenced code block, use the following:
+
+<pre>
+```diff-{language-goes-here}
+</pre>
+
+The above will cause `react-markdown` to add a
+`language-diff-{language-goes-here}` class name to the code block and call
+Prism.js to highlight the code.
+
+As an example, using `diff-typescript` to start a fenced code block ...
+
+<pre>
+```diff-typescript
++ import { Rhum } from "...";
+- import * as asserts from "https://deno.land/std@<VERSION>/testing/asserts.ts";
+
++ Rhum.asserts.assertEquals( ... );
+- asserts.assertEquals( ... );
+```
+</pre>
+
+... renders as ...
+
+![Diff + Syntax Highlighting](https://user-images.githubusercontent.com/12766301/163729976-219ae844-9b7b-4506-b02e-e16848ab488e.png)
+
+### Tabbed Code Blocks
+
+To turn a fenced code block into a tabbed code block, separate the code in the
+code block with `// @CodeTab {name of tab goes here}`.
+
+The below fenced code block (with `// @CodeTab {name of tabe goes here}`
+separators) ...
+
+```typescript
+// @CodeTab Deno
+import { Mock } from "./deps.ts";
+
+// Some cool code goes here
+// ...
+// ...
+
+// @CodeTab Node (ESM)
+import { Mock } from "@drashland/rhum";
+
+// Some cool code goes here
+// ...
+// ...
+
+// @CodeTab Node (CJS)
+const { Mock } = require("@drashland/rhum");
+
+// Some cool code goes here
+// ...
+// ...
+```
+
+... renders as ...
+
+![Tabbed Code Blocks](https://user-images.githubusercontent.com/12766301/163728514-978a901f-01e8-47df-9fd2-e5b03f1387e0.png)
+
 ## Tech Stack
 
-- Next.js
+- [Jest](https://jestjs.io/) - Testing framework
+- [Next.js](https://nextjs.org/) - Web framework
+- [Prism.js](https://prismjs.com/) - Syntax highlighting for code blocks
+- [react-markdown](https://github.com/remarkjs/react-markdown) - Used to render
+  React components from Markdown files in `/docs` directory
+- [styled-components](https://styled-components.com/) - Used to quickly style
+  React components

--- a/README.md
+++ b/README.md
@@ -90,27 +90,27 @@ As an example, using `diff-typescript` to start a fenced code block ...
 ### Tabbed Code Blocks
 
 To turn a fenced code block into a tabbed code block, separate the code in the
-code block with `// @CodeTab {name of tab goes here}`.
+code block with `// @Tab {name of tab goes here}`.
 
-The below fenced code block (with `// @CodeTab {name of tabe goes here}`
-separators) ...
+The below fenced code block (with `// @Tab {name of tabe goes here}` separators)
+...
 
 ```typescript
-// @CodeTab Deno
+// @Tab Deno
 import { Mock } from "./deps.ts";
 
 // Some cool code goes here
 // ...
 // ...
 
-// @CodeTab Node (ESM)
+// @Tab Node (ESM)
 import { Mock } from "@drashland/rhum";
 
 // Some cool code goes here
 // ...
 // ...
 
-// @CodeTab Node (CJS)
+// @Tab Node (CJS)
 const { Mock } = require("@drashland/rhum");
 
 // Some cool code goes here

--- a/pages/[...path_params].jsx
+++ b/pages/[...path_params].jsx
@@ -98,7 +98,7 @@ export default function Page(props) {
           h3: Markdown.Heading3,
           h4: Markdown.Heading4,
           li: Markdown.ListItem,
-          code: Markdown.RestyledCode,
+          code: Markdown.Code,
           pre: Markdown.Pre,
           p: Markdown.Paragraph,
           ol: Markdown.OrderedList,

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -253,6 +253,7 @@ export default function Layout(props) {
       publicRuntimeConfig.localStorageKeys.darkMode,
       !darkMode,
     );
+    Prism.highlightAll();
     setDarkMode(!darkMode);
   }
 

--- a/src/components/Markdown.jsx
+++ b/src/components/Markdown.jsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { Link } from "@styled-icons/bootstrap";
 import styled from "styled-components";
+import CodeExtended from "./markdown/CodeExtended";
 
 const flatten = (text, child) => {
   return typeof child === "string"
@@ -146,22 +147,24 @@ export const Heading4 = styled(Heading(4))`
 export const ListItem = styled.li`
 `;
 
-export const Code = function ({ className, children }) {
-  function getPrismJsClassName(ogClassName) {
-    if (ogClassName.includes("diff")) {
-      return className.replace("lang-", " language-") + " diff-highlight";
+export const PreExtended = function ({ className, children }) {
+  function renderCodeBlocks() {
+    // If we have an array, then we have multiple code blocks. Multiple code
+    // blocks means @Tab is being used inside the code block.
+    if (Array.isArray(children)) {
+      return children.map((child) => {
+        return React.cloneElement(child, { isExampleCodeBlock: true });
+      });
     }
 
-    // Default to just making sure that `language-` is used instead of `lang-`.
-    return className.replace("lang-", " language-");
+    // Otherwise, we just have a single code block
+    return children;
   }
 
   return (
-    <code
-      className={className && getPrismJsClassName(className)}
-    >
-      {children}
-    </code>
+    <pre className={className}>
+      {renderCodeBlocks()}
+    </pre>
   );
 };
 
@@ -171,24 +174,24 @@ export const Paragraph = styled.p`
   transition-property: color;
 `;
 
-export const RestyledCode = styled(Code)`
-  font-size: .85rem;
-  background: ${({ theme }) => theme.markdown.code.backgroundColor};
-  border-radius: 1rem;
-  color: ${({ theme }) => theme.markdown.code.color};
-  font-weight: 500;
-  padding: .25rem .5rem;
-  transition-duration: 0.25s;
-  transition-property: background, color;
-`;
-
-export const Pre = styled.pre`
+export const Pre = styled(PreExtended)`
   background: #2f343c !important;
   border-radius: 1rem;
+  overflow: hidden;
   ${MARGIN_BOTTOM};
 
   &[class*=language-] {
     ${MARGIN_BOTTOM};
+  }
+
+  pre {
+    background: #2f343c !important;
+    border-radius: 1rem;
+    margin-bottom: 0 !important;
+
+    &[class*=language-] {
+      margin-bottom: 0 !important;
+    }
   }
 
   code {
@@ -197,6 +200,17 @@ export const Pre = styled.pre`
     padding: 0;
     color: inherit;
   }
+`;
+
+export const Code = styled(CodeExtended)`
+  font-size: .85rem;
+  background: ${({ theme }) => theme.markdown.code.backgroundColor};
+  border-radius: 1rem;
+  color: ${({ theme }) => theme.markdown.code.color};
+  font-weight: 500;
+  padding: .25rem .5rem;
+  transition-duration: 0.25s;
+  transition-property: background, color;
 `;
 
 export const OrderedList = styled.ol`

--- a/src/components/markdown/CodeExtended.jsx
+++ b/src/components/markdown/CodeExtended.jsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { Pre } from "../Markdown";
+
+////////////////////////////////////////////////////////////////////////////////
+// FILE MARKER - STYLED COMPONENTS /////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+const ACCEPTED_CODE_TAB_NAMES = [
+  "Browser",
+  "Deno",
+  "Node (CJS)",
+  "Node (ESM JS)",
+  "Node (ESM TS)",
+];
+
+const Code = styled.code`
+  font-size: .85rem;
+  background: ${({ theme }) => theme.markdown.code.backgroundColor};
+  border-radius: 1rem;
+  color: ${({ theme }) => theme.markdown.code.color};
+  font-weight: 500;
+  padding: .25rem .5rem;
+  transition-duration: 0.25s;
+  transition-property: background, color;
+`;
+
+const Tab = styled.button`
+  font-family: 'Menlo', Helvetica, Arial, sans-serif;
+  font-size: .85rem;
+  cursor: pointer;
+  padding: 1rem;
+  background: ${({ activeTab, name }) =>
+  activeTab === name ? "#2f343c" : "#202328"};
+  color: ${({ activeTab, name }) => activeTab === name ? "#ffffff" : "#5b677e"};
+  border-right: 1px solid #444f62;
+  margin: 0;
+`;
+
+export default function CodeExtension({
+  className,
+  children,
+  /**
+   * Example code blocks use the fenced code:
+   *
+   * ```typescript
+   * something here
+   * ```
+   *
+   * ... as opposed to a regular inline code element:
+   *
+   * `something here`
+   */
+  isExampleCodeBlock,
+}) {
+  // Let's make sure we always have a string as a class name before running
+  // through this component's functions
+  className = className?.replace("lang-", " language-") || "";
+  const [activeTab, setActiveTab] = useState("Deno");
+
+  /**
+   * Get the Prims.js class name for the a code block.
+   */
+  function getPrismJsClassNameForCodeBlock(name) {
+    // If this is a `diff-` class, then make sure we have diff highlighting
+    if (className.includes("diff")) {
+      return className + " diff-highlight";
+    }
+
+    if (isNodeTab(name)) {
+      let language = "language-javascript";
+      if (isNodeTabForTypeScript(name)) {
+        language = "language-typescript";
+      }
+      return className.replace(/language-typescript/g, language);
+    }
+
+    // If we get here, let's make sure we check that a language was specified.
+    // If not, then we default to the ugly text language.
+    if (isExampleCodeBlock && !className.includes("language-")) {
+      console.warn(
+        `Markdown code block is missing syntax highlighting. Use \`\`\`<some-language> to hide this warning.`,
+      );
+      className += " language-text";
+    }
+
+    return className;
+  }
+
+  /**
+   * Is this a Node code tab?
+   *
+   * @returns True if yes, false if no.
+   */
+  function isNodeTab(codeTabName) {
+    return codeTabName?.includes("Node");
+  }
+
+  /**
+   * Is this a Node TypeScript code tab?
+   *
+   * @returns True if yes, false if no.
+   */
+  function isNodeTabForTypeScript(codeTabName) {
+    return codeTabName?.toLowerCase().includes("ESM TS");
+  }
+
+  /**
+   * Take the given code block and get the tab name from it. The tab name is
+   * the first line of the code block.
+   *
+   * @returns The tab name (the first line).
+   */
+  function getTabNameFromCodeBlock(codeBlock) {
+    return codeBlock.match(/.+\n/)[0].trim();
+  }
+
+  /**
+   * All tabbed code blocks will contain // @Tab {name of tab}. We want to
+   * strip that part out. This is what this function does.
+   *
+   * @param codeBlock - The code block containing the tab name.
+   * @param tabName - The tab name in the code to remove.
+   * @returns The code without the tab name.
+   */
+  function renderCodeBlockWithoutTabName(codeBlock, tabName) {
+    return codeBlock.replace(tabName, "").trim();
+  }
+
+  /**
+   * @returns A component that displays a single, untabbed code block.
+   */
+  function renderSingleCodeBlock() {
+    return (
+      <code
+        className={getPrismJsClassNameForCodeBlock(className)}
+      >
+        {children}
+      </code>
+    );
+  }
+
+  /**
+   * @param tabs - The tabs containing the code blocks.
+   * @returns A component that displays the given tabs as separate tabs having
+   * separate code blocks.
+   */
+  function renderTabbedCodeBlocks(tabs) {
+    return (
+      <div className="tabbed-code" style={{ overflow: "auto" }}>
+        <div style={{ display: "flex", background: "#202328" }}>
+          {tabs.map((tab) => {
+            const tabName = tab.match(/.+\n/)[0].trim();
+            return (
+              <Tab
+                activeTab={activeTab}
+                key={`tab-name-${tab}`}
+                name={tabName}
+                onClick={() => setActiveTab(tabName)}
+              >
+                {tabName}
+              </Tab>
+            );
+          })}
+        </div>
+        {tabs.map((codeBlock, index) => {
+          const tabName = getTabNameFromCodeBlock(codeBlock);
+
+          return (
+            <div
+              key={codeBlock + index}
+              style={{
+                display: activeTab === tabName ? "block" : "none",
+              }}
+            >
+              <Pre>
+                <code
+                  className={getPrismJsClassNameForCodeBlock(tabName)}
+                >
+                  {renderCodeBlockWithoutTabName(codeBlock, tabName)}
+                </code>
+              </Pre>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  /**
+   * Separate the given code into tabs by splitting on `// @Tab `.
+   *
+   * @returns An array of code blocks. Each code block belongs to a tab.
+   */
+  function separateCodeIntoTabs() {
+    const tabs = children[0].split("// @Tab ");
+    tabs.shift(); // Take off the first element which is an empty string
+    validateTabNames(tabs);
+    return tabs;
+  }
+
+  /**
+   * The only accepted tab names are in the ACCEPTED_CODE_TAB_NAMES array.
+   * This will throw an error on the page if the @Tab annotation has an
+   * invalid name.
+   */
+  function validateTabNames(tabs) {
+    tabs.forEach((codeBlock) => {
+      const tabName = getTabNameFromCodeBlock(codeBlock);
+      if (!ACCEPTED_CODE_TAB_NAMES.includes(tabName)) {
+        throw new Error(
+          `@Tab with name "${tabName}" not accepted. Use ${
+            ACCEPTED_CODE_TAB_NAMES.join(", ")
+          } only.`,
+        );
+      }
+    });
+  }
+
+  if (children && Array.isArray(children) && typeof children[0] === "string") {
+    // Tabbed code blocks MUST have at least TWO "// @Tab" tags and
+    // those tags MUST be in the following format:
+    //
+    //     // @Tab Some Name
+    //
+    // The logic below parses "//<one space>@Tab<one_space><name of tab>"
+    //
+    const tabs = separateCodeIntoTabs(children);
+
+    // If `tabs` is greater than 0, then the code block has // @Tab sections
+    if (tabs.length > 0) {
+      return renderTabbedCodeBlocks(tabs);
+    }
+  }
+
+  return renderSingleCodeBlock();
+}


### PR DESCRIPTION
Closes #143 

## Summary

Allows fenced code blocks to use `// @Tab {some tab name}` to turn code blocks into tabbed code blocks. See this PR's [README](https://github.com/drashland/website-v2/tree/feat/tabbed-code-blocks#tabbed-code-blocks) for example code.

## Other Notes

- This will allow us to write code blocks for Deno, Node, and the Browser for our modules that are cross-compatible.
- This is not being used yet. It should be used for the following:
  - #142
  - #141
  - #146 