### PR TITLE
fix(sinco/v4.x): transform V4 label to lowercase v4

### DIFF
--- a/src/services/string_service.js
+++ b/src/services/string_service.js
@@ -113,6 +113,10 @@ export function formatLabel(label) {
       to: "v3",
     },
     {
+      from: /V4/g,
+      to: "v4",
+    },
+    {
       from: /Websocket/g,
       to: "WebSocket",
     },


### PR DESCRIPTION
Lowercases the V4 in the side bar. Currently, the v is capitalized (shown below). Should be lowercase.

![Screen Shot 2022-05-15 at 08 19 14](https://user-images.githubusercontent.com/12766301/168472513-8819bc87-d244-48ef-8149-3bab65e8c4d4.png)
