### PR TITLE
chore(rhum/v2.x): spies - use note placeholder

### DIFF
--- a/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/1_class_spies.md
+++ b/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/1_class_spies.md
@@ -1,11 +1,6 @@
 # Class Spies
 
-This feature was introduced in v2.1.0-rc.1. Please make sure you are using
-v2.1.0-rc.1 (or higher) before proceeding with this tutorial. Since this feature
-is in a release candidate, its code and documentation may change. However, all
-changes made will be documented on the
-[GitHub Releases](https://github.com/drashland/rhum/releases) page until this
-feature is considered stable. No breaking changes are expected to occur.
+{{ note_since: v2.1.0 }}
 
 ## Table of Contents
 

--- a/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/2_object_method_spies.md
+++ b/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/2_object_method_spies.md
@@ -1,11 +1,6 @@
 # Object Method Spies
 
-This feature was introduced in v2.1.0-rc.1. Please make sure you are using
-v2.1.0-rc.1 (or higher) before proceeding with this tutorial. Since this feature
-is in a release candidate, its code and documentation may change. However, all
-changes made will be documented on the
-[GitHub Releases](https://github.com/drashland/rhum/releases) page until this
-feature is considered stable. No breaking changes are expected to occur.
+{{ note_since: v2.1.0 }}
 
 ## Table of Contents
 

--- a/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/3_function_expression_spies.md
+++ b/docs/rhum/v2.x/2_tutorials/2_test_doubles/4_spies/3_function_expression_spies.md
@@ -1,11 +1,6 @@
 # Function Expression Spies
 
-This feature was introduced in v2.1.0-rc.1. Please make sure you are using
-v2.1.0-rc.1 (or higher) before proceeding with this tutorial. Since this feature
-is in a release candidate, its code and documentation may change. However, all
-changes made will be documented on the
-[GitHub Releases](https://github.com/drashland/rhum/releases) page until this
-feature is considered stable. No breaking changes are expected to occur.
+{{ note_since: v2.1.0 }}
 
 ## Table of Contents
 


### PR DESCRIPTION
Post release chore (Rhum v2.1.0) for Spies "since version" note